### PR TITLE
Typo in readme instructions and changed Mac default behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ By default, MFPR Java builds the native libraries using dynamic linking. As a re
 1. Download the latest versions of GMP and MPFR from the web, and unzip their source.
 2. in the gmp directory, run `./configure --with-pic --build=<arch>; make`
 3. in the mpfr directory, run `./configure --with-gmp-include=<gmpdir> --with-gmp-lib=<gmpdir>/.libs --with-pic --build=<arch>; make`
-4. in the mpfr-java directory, run `mvn install -Dmpfr.cppflags='-I<mpfrdir>/src -I<gmpdir>' -Dmpfr.libs='<mpfrdir>/src/.libs/libmpfr.a <gmpdir>/.libs/libgmp.a' --build=<arch>`
+4. in the mpfr-java directory, run `mvn install -Dmpfr.cppflags='-I<mpfrdir>/src -I<gmpdir>' -Dmpfr.libs='<mpfrdir>/src/.libs/libmpfr.a <gmpdir>/.libs/libgmp.a' -Dmpfr.build=<arch>`
 
 Where `<arch>` is the architecture and OS of system you wish to support (e.g. "x86\_64-linux").
 

--- a/pom.xml
+++ b/pom.xml
@@ -130,10 +130,7 @@
     </profile>
  
     <profile>
-      <id>mac</id>
-      <activation>
-        <os><family>mac</family></os>
-      </activation>
+      <id>mac-universal</id>
       <build>
         <plugins>
           <plugin>


### PR DESCRIPTION
The maven profile for Mac does not work on 10.13 at least, the default profile does.