### PR TITLE
Build binaries on Ubuntu 18.04

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+vendor/
+target/
+output/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+.m2/
 .classpath
 .project
 .settings
 target
 vendor/
+output/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:bionic
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN    apt-get update            \
+    && apt-get install --yes     \
+        autogen                  \
+        automake                 \
+        autoconf                 \
+        autotools-dev            \
+        build-essential          \
+        curl                     \
+        gcc                      \
+        git                      \
+        libtool                  \
+        openjdk-8-jdk            \
+        shtool
+
+ADD . /src
+ADD https://dlcdn.apache.org/maven/maven-3/3.8.3/binaries/apache-maven-3.8.3-bin.tar.gz /src
+
+RUN cd /src && tar xvf apache-maven-3.8.3-bin.tar.gz
+ENV PATH="/src/apache-maven-3.8.3/bin:${PATH}"
+
+VOLUME /output
+
+WORKDIR /src
+CMD ["src/main/scripts/build-linux64.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ ENV PATH="/src/apache-maven-3.8.3/bin:${PATH}"
 VOLUME /output
 
 WORKDIR /src
-CMD ["src/main/scripts/build-linux64.sh"]
+ENTRYPOINT ["src/main/scripts/build-linux64.sh"]

--- a/README.md
+++ b/README.md
@@ -77,6 +77,22 @@ to run in parallel when building GMP and MPFR.
 
 ## Deployment
 
+### Linux 64-bit Target
+
+To ensure the pre-built native code links agains a suitably old version of libc,
+the binaries should be built on **Ubuntu Bionic (18.04)**. A Dockerfile is
+provided to do so:
+
+```console
+docker build -t mpfr-bionic .
+docker run -v `pwd`/output:/output mpfr-bionic
+```
+
+Then, when deploying, use the generated files in `output/` rather than
+`target/`.
+
+### Maven
+
 To deploy a new version of the library to Maven:
 
 ```console

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ provided to do so:
 
 ```console
 docker build -t mpfr-bionic .
-docker run -v `pwd`/output:/output mpfr-bionic
+docker run --rm -it -v `pwd`/output:/output mpfr-bionic $(id -u) $(id -g)
 ```
 
 Then, when deploying, use the generated files in `output/` rather than

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kframework.mpfr_java</groupId>
   <artifactId>mpfr_java</artifactId>
-  <version>1.2</version>
+  <version>1.3</version>
   <name>HawtJNI MPFR Java Bindings</name>
 
   <dependencies>

--- a/src/main/scripts/build-linux64.sh
+++ b/src/main/scripts/build-linux64.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -x
+
 ./src/main/scripts/ci-download.sh
 ./src/main/scripts/ci-build.sh
 cp -r ./target/* /output
+chown -R "$1":"$2" /output

--- a/src/main/scripts/build-linux64.sh
+++ b/src/main/scripts/build-linux64.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+./src/main/scripts/ci-download.sh
+./src/main/scripts/ci-build.sh
+cp -r ./target/* /output


### PR DESCRIPTION
The 1.2 binaries I deployed were built on 21.10; this breaks the libc dependency on older versions.

This PR adds a Dockerfile that builds the linux64 binaries on a bionic image; the macos ones still need to be done on an actual machine. The version is bumped as well to avoid inadvertent problems through changing 1.2 in place.