### PR TITLE
Version bump, lipo universal JAR instructions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.kframework.mpfr_java</groupId>
   <artifactId>mpfr_java</artifactId>
-  <version>1.3</version>
+  <version>1.4</version>
   <name>HawtJNI MPFR Java Bindings</name>
 
   <dependencies>


### PR DESCRIPTION
One final version bump to avoid confusion, along with the instructions for creating a universal library for macOS as discussed.